### PR TITLE
add default platform for dotnet-ci

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -22,6 +22,7 @@ on:
       image-tag-parameter:
         type: string
       platform:
+        default: "ocp"
         type: string
       test:
         default: true


### PR DESCRIPTION
## What does this change do? Explained to a 🐵

- add default platform for dotnet-ci

## How have I tested this?

- [X] 😨 I tested it in my brain (This is fine. What could go wrong? 🔥😅)
- [ ] 😬 Tested manually on my machine or in a deployed environment (Pushed buttons until it “felt” okay. 🤷‍♂️)
- [ ] 🏆 Automated tests (This is **real** testing. Be proud. 💪🚀)  
- [ ] ✏️ Other (please describe):

## Additional Context
