### PR TITLE
default image-tag-paramter for dotnet-ci

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -20,6 +20,7 @@ on:
         default: "Category!=e2e"
         type: string
       image-tag-parameter:
+        default: "image.tag"
         type: string
       platform:
         default: "ocp"


### PR DESCRIPTION
## What does this change do? Explained to a 🐵

- default image-tag-paramter for dotnet-ci

## How have I tested this?

- [x] 😨 I tested it in my brain (This is fine. What could go wrong? 🔥😅)
- [ ] 😬 Tested manually on my machine or in a deployed environment (Pushed buttons until it “felt” okay. 🤷‍♂️)
- [ ] 🏆 Automated tests (This is **real** testing. Be proud. 💪🚀)  
- [ ] ✏️ Other (please describe):

## Additional Context
