### PR TITLE
Add working-directory support for .NET and Node.js CI workflows in monorepo

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -24,6 +24,10 @@ on:
         type: string
         required: false
         default: "Dockerfile"
+      working-directory:
+        description: "Path to the directory containing the Dockerfile"
+        default: "."
+        type: string
     outputs:
       image:
         description: "The output representing the built image"
@@ -90,10 +94,10 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ inputs.working-directory }}
           push: ${{ inputs.push }}
           tags: ${{ steps.set-image.outputs.image }}
-          file: ${{ inputs.dockerfile }}
+          file: ${{ inputs.working-directory != '.' && format('{0}/{1}', inputs.working-directory, inputs.dockerfile) || inputs.dockerfile }}
           build-args: ${{ steps.export-build-args.outputs.buildArgs }}
           secrets: ${{ secrets.container-secrets }}
           cache-from: type=gha

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -79,6 +79,7 @@ jobs:
       registry-url: "quay.io"
       image-name: "quay.io/agronod/ghcr.io/${{ github.repository }}"
       tag: ${{ needs.next-version.outputs.version }}
+      working-directory: ${{ inputs.working-directory }}
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -6,6 +6,10 @@ on:
       dotnet-version:
         required: true
         type: string
+      working-directory:
+        description: "Path to the directory containing the .NET solution or project"
+        default: "."
+        type: string
       rhacs-central-endpoint:
         description: "The endpoint URL of the RHACS Central server for authentication."
         type: string
@@ -55,6 +59,7 @@ jobs:
     uses: ./.github/workflows/dotnet-test.yml
     with:
       dotnet-version: ${{ inputs.dotnet-version }}
+      working-directory: ${{ inputs.working-directory }}
       test-filter: ${{ inputs.test-filter }}
       enabled: ${{ inputs.test }}
     secrets:

--- a/.github/workflows/dotnet-pull-request.yml
+++ b/.github/workflows/dotnet-pull-request.yml
@@ -6,6 +6,10 @@ on:
       dotnet-version:
         required: true
         type: string
+      working-directory:
+        description: "Path to the directory containing the .NET solution or project"
+        default: "."
+        type: string
       rhacs-central-endpoint:
         description: "The endpoint URL of the RHACS Central server for authentication."
         type: string
@@ -15,7 +19,7 @@ on:
         type: string
       check-image:
         default: true
-        type: boolean        
+        type: boolean
     secrets:
       github-user:
         description: "Github username for the container registry"
@@ -41,6 +45,7 @@ jobs:
     uses: ./.github/workflows/dotnet-test.yml
     with:
       dotnet-version: ${{ inputs.dotnet-version }}
+      working-directory: ${{ inputs.working-directory }}
       test-filter: ${{ inputs.test-filter }}
     secrets:
       github-user: ${{ secrets.github-user }}

--- a/.github/workflows/dotnet-pull-request.yml
+++ b/.github/workflows/dotnet-pull-request.yml
@@ -66,6 +66,7 @@ jobs:
       registry-url: "quay.io"
       image-name: "quay.io/agronod/ghcr.io/${{ github.repository }}"
       tag: ${{ needs.next-version.outputs.version }}
+      working-directory: ${{ inputs.working-directory }}
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1,10 +1,14 @@
-name: Test Nestjs application
+name: Test .NET application
 
 on:
   workflow_call:
     inputs:
       dotnet-version:
         required: true
+        type: string
+      working-directory:
+        description: "Path to the directory containing the .NET solution or project"
+        default: "."
         type: string
       test-filter:
         required: true
@@ -35,6 +39,7 @@ jobs:
 
       - name: Restore
         if: ${{ inputs.enabled }}
+        working-directory: ${{ inputs.working-directory }}
         run: |
           dotnet restore
         env:
@@ -43,8 +48,10 @@ jobs:
 
       - name: Build
         if: ${{ inputs.enabled }}
+        working-directory: ${{ inputs.working-directory }}
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
         if: ${{ inputs.enabled }}
+        working-directory: ${{ inputs.working-directory }}
         run: dotnet test --no-restore --verbosity normal --filter ${{ inputs.test-filter }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -72,6 +72,7 @@ jobs:
       registry-url: "quay.io"
       image-name: "quay.io/agronod/ghcr.io/${{ github.repository }}"
       tag: ${{ needs.next-version.outputs.version }}
+      working-directory: ${{ inputs.working-directory }}
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -26,6 +26,9 @@ on:
       check-image:
         default: true
         type: boolean
+      image-tag-parameter:
+        default: "image.tag"
+        type: string
     secrets:
       github-user:
         description: "Github username for the container registry"
@@ -101,5 +104,6 @@ jobs:
       tag: ${{ needs.build-and-push-image.outputs.tag }}
       application-name: ${{ inputs.application-name }}
       application-folder: ${{ inputs.application-folder }}
+      image-tag-parameter: ${{ inputs.image-tag-parameter }}
     secrets:
       github-token: ${{ secrets.github-token }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -6,6 +6,10 @@ on:
       node-version:
         default: "20.15.0"
         type: string
+      working-directory:
+        description: "Path to the directory containing the Node.js project"
+        default: "."
+        type: string
       rhacs-central-endpoint:
         description: "The endpoint URL of the RHACS Central server for authentication."
         type: string
@@ -47,6 +51,7 @@ jobs:
     uses: ./.github/workflows/node-test.yml
     with:
       node-version: ${{ inputs.node-version }}
+      working-directory: ${{ inputs.working-directory }}
       enabled: ${{ inputs.test }}
     secrets:
       github-token: ${{ secrets.github-token }}

--- a/.github/workflows/node-pull-request.yml
+++ b/.github/workflows/node-pull-request.yml
@@ -6,6 +6,10 @@ on:
       node-version:
         default: "20.15.0"
         type: string
+      working-directory:
+        description: "Path to the directory containing the Node.js project"
+        default: "."
+        type: string
       rhacs-central-endpoint:
         description: "The endpoint URL of the RHACS Central server for authentication."
         type: string
@@ -38,6 +42,7 @@ jobs:
     uses: ./.github/workflows/node-test.yml
     with:
       node-version: ${{ inputs.node-version }}
+      working-directory: ${{ inputs.working-directory }}
       enabled: ${{ inputs.test }}
     secrets:
       github-token: ${{ secrets.github-token }}

--- a/.github/workflows/node-pull-request.yml
+++ b/.github/workflows/node-pull-request.yml
@@ -62,6 +62,7 @@ jobs:
       registry-url: "quay.io"
       image-name: "quay.io/agronod/ghcr.io/${{ github.repository }}"
       tag: ${{ needs.next-version.outputs.version }}
+      working-directory: ${{ inputs.working-directory }}
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,10 +1,14 @@
-name: Test Nestjs application
+name: Test Node.js application
 
 on:
   workflow_call:
     inputs:
       node-version:
         required: true
+        type: string
+      working-directory:
+        description: "Path to the directory containing the Node.js project"
+        default: "."
         type: string
       enabled:
         default: true
@@ -32,10 +36,12 @@ jobs:
 
       - name: Install dependencies
         if: ${{ inputs.enabled }}
+        working-directory: ${{ inputs.working-directory }}
         run: npm ci
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
 
       - name: Run tests
         if: ${{ inputs.enabled }}
+        working-directory: ${{ inputs.working-directory }}
         run: npm test


### PR DESCRIPTION
## 🎯 WHY - What does this change do? Explained to a 🐵

The .NET and Node.js CI workflows were failing for monorepo projects! 🙈 When you have your projects in subdirectories (like `services/my-api` or `apps/my-frontend` instead of the root), the dotnet and npm commands couldn't find your solution/project files. This meant teams using monorepo structures couldn't use our shared workflows at all.

This PR fixes that by adding a `working-directory` parameter that tells the workflows where to look for your projects. Now monorepo projects can happily use these workflows! 🎉

## 🔧 HOW - How have we implemented it?

Added a new `working-directory` input parameter to all .NET and Node.js workflows with a default value of "." for backward compatibility:

**Updated .NET workflows:**
- `dotnet-ci.yml` - Main CI workflow
- `dotnet-test.yml` - Test workflow with working-directory applied to restore, build, and test commands
- `dotnet-pull-request.yml` - PR workflow

**Updated Node.js workflows:**
- `node-ci.yml` - Main CI workflow  
- `node-test.yml` - Test workflow with working-directory applied to npm ci and npm test commands
- `node-pull-request.yml` - PR workflow

Also fixed incorrect workflow names ("Test Nestjs application" → "Test Node.js/Test .NET application").

## ✅ How have I tested this?

- [ ] 😨 I tested it in my brain (This is fine. What could go wrong? 🔥😅)
- [x] 😬 Tested manually on my machine or in a deployed environment (Pushed buttons until it "felt" okay. 🤷‍♂️)
- [ ] 🏆 Automated tests (This is **real** testing. Be proud. 💪🚀)  
- [ ] ✏️ Other (please describe):

## 📝 Additional Context

**Usage examples for monorepo projects:**

**.NET project:**
```yaml
uses: ./.github/workflows/dotnet-ci.yml
with:
  dotnet-version: '8.0'
  working-directory: 'services/my-dotnet-service'  # Path to your .NET project
  application-name: 'my-app'
  application-folder: 'apps/my-app'
  # ... other parameters
```

**Node.js project:**
```yaml
uses: ./.github/workflows/node-ci.yml
with:
  node-version: '20.15.0'
  working-directory: 'apps/my-frontend'  # Path to your Node.js project
  application-name: 'my-app'
  application-folder: 'apps/my-app'
  # ... other parameters
```

This change is fully backward compatible - existing workflows without the `working-directory` parameter will continue to work as before.