### PR TITLE
ci: disable trivy image scanning by default

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -72,7 +72,7 @@ on:
         default: true
         type: boolean
       check-image:
-        default: true
+        default: false
         type: boolean
       environment:
         description: "Override environment (e.g., dev, test, staging, production). If not provided, will be calculated from branch."

--- a/.github/workflows/dotnet-pull-request.yml
+++ b/.github/workflows/dotnet-pull-request.yml
@@ -47,7 +47,7 @@ on:
         default: "Category!=e2e"
         type: string
       check-image:
-        default: true
+        default: false
         type: boolean
       enforce-scanning:
         default: false

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -69,7 +69,7 @@ on:
         required: false
         type: string
       check-image:
-        default: true
+        default: false
         type: boolean
       environment:
         description: "Override environment (e.g., dev, test, staging, production). If not provided, will be calculated from branch."

--- a/.github/workflows/go-pull-request.yml
+++ b/.github/workflows/go-pull-request.yml
@@ -46,7 +46,7 @@ on:
         default: true
         type: boolean
       check-image:
-        default: true
+        default: false
         type: boolean
       enforce-scanning:
         default: false

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -65,7 +65,7 @@ on:
         required: true
         type: string
       check-image:
-        default: true
+        default: false
         type: boolean
       dockerfile:
         description: "The path to the Dockerfile relative to the repository root"

--- a/.github/workflows/node-pull-request.yml
+++ b/.github/workflows/node-pull-request.yml
@@ -55,7 +55,7 @@ on:
         default: true
         type: boolean
       check-image:
-        default: true
+        default: false
         type: boolean
       enforce-scanning:
         default: false

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -60,7 +60,7 @@ on:
         default: true
         type: boolean
       check-image:
-        default: true
+        default: false
         type: boolean
       enforce-scanning:
         default: false

--- a/.github/workflows/python-pull-request.yml
+++ b/.github/workflows/python-pull-request.yml
@@ -43,7 +43,7 @@ on:
         default: true
         type: boolean
       check-image:
-        default: true
+        default: false
         type: boolean
       enforce-scanning:
         default: false


### PR DESCRIPTION
Set check-image default to false across all CI/CD and pull request workflows (dotnet, go, node, python) to skip Trivy scans until we are actively reviewing scan results.

## How have I tested this?

- [ ] 😨 I tested it in my brain (This is fine. What could go wrong? 🔥😅)
- [ ] 😬 Tested manually on my machine or in a deployed environment (Pushed buttons until it “felt” okay. 🤷‍♂️)
- [ ] 🏆 Automated tests (This is **real** testing. Be proud. 💪🚀)  
- [ ] ✏️ Other (please describe):

## Additional Context
